### PR TITLE
Ajout d'un avertissement concernant l'espace après le # pour les titres

### DIFF
--- a/pages/markdown.html
+++ b/pages/markdown.html
@@ -58,6 +58,9 @@ description: Un guide simple pour apprendre Markdown.
 ## Un titre un peu moins important
 ### Un titre encore moins important</code></pre>
 
+⚠️  Attention, une erreur commune est d’oublier l’espace après le
+<code>#</code>. Il faut bien le mettre pour que le titre soit un titre !
+
 <p>
     Vous pouvez également souligner le texte en utilisant <code>===</code> ou
     <code>---</code> pour créer des titres.


### PR DESCRIPTION
Salut Marien,

Cette PR, c'est surtout une issue avec du code attaché et pas du tout une "request"

Une amie qui utilise Scribouilli (... wait, est-ce que t'es au courant de [Scribouilli](https://scribouilli.github.io/scribouilli/)  ? Bon, en rapide, c'est un truc pour faire un petit site web en markdown. Et pour expliquer aux gens qui ne connaissent pas le markdown, on a fait un lien [vers ta page](https://flus.fr/carnet/markdown.html) parce qu'on la trouve bien. Merci beaucoup, d'ailleurs !!)

Donc, une amie qui utilise Scribouilli est allée sur ta page, elle a appris Markdown toute seule grâce à ta page :tada: et elle n'a pas réussi à faire des titres :-(
Et l'erreur qu'elle a fait partout, c'était d'oublier l'espace après le `#`. Et ça m'a rappelé que ce n'est pas la première fois que je vois les débutant.e.s faire cette erreur. Donc je me suis dit que ça vaudrait le coup de rajouter une phrase d'avertissement dans ton guide

J'ai fait une proposition ici et on peut complètement la jeter

